### PR TITLE
fixed crash when calling SDL.IMG.load

### DIFF
--- a/src/node_sdl.cc
+++ b/src/node_sdl.cc
@@ -850,9 +850,8 @@ Handle<Value> sdl::IMG::Load(const Arguments& args) {
     )));
   }
 
-  Handle<Object> ret = Object::New();
-  SurfaceWrapper* wrap = new SurfaceWrapper(ret);
-  wrap->surface_ = image;
+  NEW_WRAPPED(image, SurfaceWrapper, ret)
+
   return scope.Close(ret);
 }
 


### PR DESCRIPTION
In node v0.10.29 I was doing something like:

```
var surface = SDL.IMG.load("./images/logo.png");
```

which always led to this crash:

```
node: /usr/include/nodejs/src/node_object_wrap.h:71: void node::ObjectWrap::Wrap(v8::Handle<v8::Object>): Assertion `handle->InternalFieldCount() > 0' failed.
```

After modifying sdl::IMG::Load() to use the NEW_WRAPPED macro, I can successfully use images.
